### PR TITLE
Reworked compile receipts

### DIFF
--- a/Receipt/index.spec.ts
+++ b/Receipt/index.spec.ts
@@ -259,27 +259,99 @@ describe("Receipt", () => {
 	it("compile", async () => {
 		const receiptA = new Uint8Array(await fs.readFile("./Receipt/receiptA.pdf"))
 		const receiptB = new Uint8Array(await fs.readFile("./Receipt/receiptB.pdf"))
-		const receipts: { details: model.Receipt; file: Uint8Array }[] = [
+		const receipts: { costCenter: string; receipts: { details: model.Receipt; file: Uint8Array }[] }[] = [
 			{
-				details: {
-					id: "AAAA",
-					original: "placeholder",
-					total: [{ net: [990, "EUR"], vat: [10, "EUR"] }],
-					date: "2022-09-20T13:37:42Z",
-				},
-				file: receiptA,
+				costCenter: "Sales",
+				receipts: [
+					{
+						details: {
+							id: "AAAA",
+							original: "placeholder",
+							total: [{ net: [990, "EUR"], vat: [10, "EUR"] }],
+							date: "2022-09-20T13:37:42Z",
+						},
+						file: receiptA,
+					},
+					{
+						details: {
+							id: "BBBB",
+							original: "placeholder",
+							total: [{ net: [1327, "EUR"], vat: [10, "EUR"] }],
+							date: "2022-09-20T13:37:42Z",
+						},
+						file: receiptB,
+					},
+				],
 			},
 			{
-				details: {
-					id: "BBBB",
-					original: "placeholder",
-					total: [{ net: [1327, "EUR"], vat: [10, "EUR"] }],
-					date: "2022-09-20T13:37:42Z",
-				},
-				file: receiptB,
+				costCenter: "Marketing",
+				receipts: [
+					{
+						details: {
+							id: "AAAA",
+							original: "placeholder",
+							total: [{ net: [11110, "EUR"], vat: [1000, "EUR"] }],
+							date: "2022-09-20T13:37:42Z",
+						},
+						file: receiptA,
+					},
+					{
+						details: {
+							id: "BBBB",
+							original: "placeholder",
+							total: [{ net: [1327000, "EUR"], vat: [10, "EUR"] }],
+							date: "2022-09-20T13:37:42Z",
+						},
+						file: receiptB,
+					},
+				],
+			},
+			{
+				costCenter: "Cars",
+				receipts: [
+					{
+						details: {
+							id: "AAAA",
+							original: "placeholder",
+							total: [{ net: [111101, "EUR"], vat: [1000, "EUR"] }],
+							date: "2022-09-20T13:37:42Z",
+						},
+						file: receiptA,
+					},
+					{
+						details: {
+							id: "BBBB",
+							original: "placeholder",
+							total: [{ net: [13200, "EUR"], vat: [10, "EUR"] }],
+							date: "2022-09-20T13:37:42Z",
+						},
+						file: receiptB,
+					},
+					{
+						details: {
+							id: "BBBB",
+							original: "placeholder",
+							total: [{ net: [130, "EUR"], vat: [10, "EUR"] }],
+							date: "2022-09-20T13:37:42Z",
+						},
+						file: receiptB,
+					},
+					{
+						details: {
+							id: "BBBB",
+							original: "placeholder",
+							total: [{ net: [15500, "EUR"], vat: [10, "EUR"] }],
+							date: "2022-09-20T13:37:42Z",
+						},
+						file: receiptB,
+					},
+				],
 			},
 		]
-		const receiptResult = await model.Receipt.compile(receipts, delegation, { start: "2022-09-19", end: "2022-09-21" })
+		const receiptResult = await model.Receipt.compile(receipts, "Issuefab AB", {
+			start: "2022-09-19",
+			end: "2022-09-21",
+		})
 		await fs.writeFile("./Receipt/receiptResult.pdf", receiptResult)
 	})
 })

--- a/Receipt/index.ts
+++ b/Receipt/index.ts
@@ -92,7 +92,7 @@ export namespace Receipt {
 		const lineMargin = 1
 		const headers = ["Page", "Vat", "Net", "Gross", "Currency"]
 		const receiptsPerIndexPage = (height - 2 * yMargin - fontSize / 2) / lineHeight
-		const ccStartPage: Record<string, number> = {}
+		const costCenterIndex: Record<string, number> = {}
 		const frontPage = pdfDoc.addPage([width, height])
 		const indexPages = Array.from({
 			length: Math.ceil(
@@ -106,7 +106,7 @@ export namespace Receipt {
 			for (const CostCenter of indexPage) {
 				const page = pdfDoc.addPage([width, height])
 				page.drawText(`Summary for cost center: ${CostCenter.costCenter}`, { x: xMargin, y: height - yMargin })
-				ccStartPage[CostCenter.costCenter] = pdfDoc.getPageCount()
+				costCenterIndex[CostCenter.costCenter] = pdfDoc.getPageCount()
 				height -= 20
 				headers.forEach((header, index) =>
 					page.drawText(header, {
@@ -187,7 +187,7 @@ export namespace Receipt {
 			)
 			const cellText = [
 				`${costCenter.costCenter}`,
-				`${ccStartPage[costCenter.costCenter]}`,
+				`${costCenterIndex[costCenter.costCenter]}`,
 				`${totalVat}`,
 				`${totalNet}`,
 				`${totalNet + totalVat}`,

--- a/Receipt/index.ts
+++ b/Receipt/index.ts
@@ -91,7 +91,7 @@ export namespace Receipt {
 		const lineHeight = 15
 		const lineThickness = 1
 		const lineMargin = 1
-		const headers = ["Page", "Vat", "Net", "Gross", "Currency"] //Cost center summary
+		const headers = ["Page", "Vat", "Net", "Gross", "Currency"]
 		const receiptsPerIndexPage = (height - 2 * yMargin - fontSize / 2) / lineHeight
 		const ccStartPage: Record<string, number> = {}
 
@@ -134,7 +134,6 @@ export namespace Receipt {
 						[0, 0]
 					)
 
-					// vCostcenter summary
 					const cellText = [
 						`${pdfDoc.getPageCount() + indexPages.length - i}`,
 						`${vat} `,
@@ -185,10 +184,6 @@ export namespace Receipt {
 			thickness: lineThickness,
 		})
 
-		/**
-		 * Frontpage summary, works.
-		 * Need to count length per costcenter
-		 */
 		for (const costCenter of receiptData) {
 			const costCenterCurrency = costCenter.receipts[0].details.total[0].net[1]
 			const [totalVat, totalNet] = costCenter.receipts.reduce(
@@ -197,7 +192,6 @@ export namespace Receipt {
 				[0, 0]
 			)
 
-			//Frontpage summary
 			const cellText = [
 				`${costCenter.costCenter}`,
 				`${ccStartPage[costCenter.costCenter]}`,
@@ -214,6 +208,9 @@ export namespace Receipt {
 					font: font,
 				})
 			})
+		}
+		for (let i = 1; i <= pdfDoc.getPageCount(); i++) {
+			pdfDoc.getPage(i).drawText(`${i}/${pdfDoc.getPageCount()}`, { x: 20, y: 20, size: 12 })
 		}
 		result = await pdfDoc.save()
 		return result

--- a/Receipt/index.ts
+++ b/Receipt/index.ts
@@ -71,8 +71,8 @@ export namespace Receipt {
 		)
 	}
 	export async function compile(
-		receipts: { details: Receipt; file: Uint8Array }[],
-		delegation: Delegation.Data,
+		receiptData: { costCenter: string; receipts: { details: Receipt; file: Uint8Array }[] }[],
+		organisation: string,
 		dateRange: isoly.DateRange
 	): Promise<Uint8Array> {
 		let result: Uint8Array | undefined = undefined
@@ -80,71 +80,86 @@ export namespace Receipt {
 		const font = await pdfDoc.embedFont(PDFLib.StandardFonts.Courier)
 		pdfDoc.setAuthor("Issuefab AB")
 		pdfDoc.setCreationDate(new Date())
-		const [width, height] = PDFLib.PageSizes.A4
+		const width = PDFLib.PageSizes.A4[0]
+		let height = PDFLib.PageSizes.A4[1]
+
 		const fontSize = 12
 		const headerSize = Math.round(fontSize * 1.33)
 		const xMargin = 30
 		const yMargin = 4 * fontSize
-		const cellWidth = 100
+		const cellWidth = 90
 		const lineHeight = 15
 		const lineThickness = 1
 		const lineMargin = 1
-		const headers = ["Page", "Vat", "Net", "Gross", "Currency"]
+		const headers = ["Page", "Vat", "Net", "Gross", "Currency"] //Cost center summary
 		const receiptsPerIndexPage = (height - 2 * yMargin - fontSize / 2) / lineHeight
+		const ccStartPage: Record<string, number> = {}
 
 		const frontPage = pdfDoc.addPage([width, height])
 
-		const indexPages = Array.from({ length: Math.ceil(receipts.length / receiptsPerIndexPage) }).map((_, pageNumber) =>
-			receipts.slice(pageNumber * receiptsPerIndexPage, (pageNumber + 1) * receiptsPerIndexPage)
+		const indexPages = Array.from({
+			length: Math.ceil(
+				receiptData.reduce((total, costCenter) => total + costCenter.receipts.length, 0) / receiptsPerIndexPage
+			),
+		}).map((_, pageNumber) =>
+			receiptData.slice(pageNumber * receiptsPerIndexPage, (pageNumber + 1) * receiptsPerIndexPage)
 		)
-		let totalVat = 0
-		let totalNet = 0
-		for (const [i, indexPage] of indexPages.entries()) {
-			const page = pdfDoc.insertPage(1 + i, [width, height])
-			headers.forEach((header, index) =>
-				page.drawText(header, {
-					x: xMargin + index * cellWidth,
-					y: height - yMargin,
-					size: headerSize,
-				})
-			)
-			page.moveTo(xMargin, height - yMargin - fontSize / 2)
-			page.drawLine({
-				start: { x: xMargin, y: height - yMargin - lineThickness - lineMargin },
-				end: { x: width - xMargin, y: height - yMargin - lineThickness - lineMargin },
-				thickness: lineThickness,
-			})
-			for (const receipt of indexPage) {
-				const currency = receipt.details.total[0].net[1]
-				const [net, vat] = receipt.details.total.reduce<[number, number]>(
-					([n, v], { net: [net], vat: [vat] }) => [n + net, v + vat],
-					[0, 0]
-				)
-				const cellText = [
-					`${pdfDoc.getPageCount() + indexPages.length - i}`,
-					`${vat}`,
-					`${net}`,
-					`${net + vat}`,
-					currency,
-				]
-				page.moveDown(lineHeight)
-				cellText.forEach((text, index) => {
-					page.drawText(text, {
-						x: xMargin + index * cellWidth,
-						size: fontSize,
-						font: font,
-					})
-				})
-				const newFile = await PDFLib.PDFDocument.load(receipt.file)
-				const copiedPages = await pdfDoc.copyPages(newFile, newFile.getPageIndices())
-				copiedPages.forEach(page => pdfDoc.addPage(page))
 
-				totalVat = isoly.Currency.add(currency, totalVat, vat)
-				totalNet = isoly.Currency.add(currency, totalNet, net)
+		for (const [i, indexPage] of indexPages.entries()) {
+			for (const CostCenter of indexPage) {
+				const page = pdfDoc.addPage([width, height])
+
+				page.drawText(`Summary for cost center: ${CostCenter.costCenter}`, { x: xMargin, y: height - yMargin })
+				ccStartPage[CostCenter.costCenter] = pdfDoc.getPageCount()
+				height -= 20
+				headers.forEach((header, index) =>
+					page.drawText(header, {
+						x: xMargin + index * cellWidth,
+						y: height - yMargin,
+						size: headerSize,
+					})
+				)
+				page.moveTo(xMargin, height - yMargin - fontSize / 2)
+
+				page.drawLine({
+					start: { x: xMargin, y: height - yMargin - lineThickness - lineMargin },
+					end: { x: width - xMargin, y: height - yMargin - lineThickness - lineMargin },
+					thickness: lineThickness,
+				})
+
+				for (const receipt of CostCenter.receipts) {
+					const currency = receipt.details.total[0].net[1]
+					const [net, vat] = receipt.details.total.reduce<[number, number]>(
+						([n, v], { net: [net], vat: [vat] }) => [n + net, v + vat],
+						[0, 0]
+					)
+
+					// vCostcenter summary
+					const cellText = [
+						`${pdfDoc.getPageCount() + indexPages.length - i}`,
+						`${vat} `,
+						`${net}`,
+						`${net + vat}`,
+						currency,
+					]
+					page.moveDown(lineHeight)
+					cellText.forEach((text, index) => {
+						page.drawText(text, {
+							x: xMargin + index * cellWidth,
+							size: fontSize,
+							font: font,
+						})
+					})
+					const newFile = await PDFLib.PDFDocument.load(receipt.file)
+					const copiedPages = await pdfDoc.copyPages(newFile, newFile.getPageIndices())
+					copiedPages.forEach(page => {
+						pdfDoc.addPage(page)
+					})
+				}
 			}
 		}
 
-		frontPage.drawText(`Invoice summary: ${delegation.costCenter}`, {
+		frontPage.drawText(`Invoice summary: ${organisation}`, {
 			x: xMargin,
 			y: (height * 2) / 3,
 			size: headerSize,
@@ -156,7 +171,7 @@ export namespace Receipt {
 			size: fontSize,
 		})
 		frontPage.moveDown(lineHeight * 50)
-		;["Pages", "Vat", "Net", "Gross", "Currency"].forEach((header, index) =>
+		;["Cost center", "Pages", "Vat", "Net", "Gross", "Currency"].forEach((header, index) =>
 			frontPage.drawText(header, {
 				x: xMargin + index * cellWidth,
 				y: height / 2,
@@ -169,22 +184,37 @@ export namespace Receipt {
 			end: { x: width - xMargin, y: height / 2 - lineThickness - lineMargin },
 			thickness: lineThickness,
 		})
-		const cellText = [
-			`${pdfDoc.getPageCount()}`,
-			`${totalVat}`,
-			`${totalNet}`,
-			`${totalNet + totalVat}`,
-			`${delegation.amount[1]}`,
-		]
-		frontPage.moveDown(lineHeight)
-		cellText.forEach((text, index) => {
-			frontPage.drawText(text, {
-				x: xMargin + index * cellWidth,
-				size: fontSize,
-				font: font,
-			})
-		})
 
+		/**
+		 * Frontpage summary, works.
+		 * Need to count length per costcenter
+		 */
+		for (const costCenter of receiptData) {
+			const costCenterCurrency = costCenter.receipts[0].details.total[0].net[1]
+			const [totalVat, totalNet] = costCenter.receipts.reduce(
+				([vat, net], receipt) =>
+					receipt.details.total.reduce(([v, n], { net: [net], vat: [vat] }) => [net + v, vat + n], [vat, net]),
+				[0, 0]
+			)
+
+			//Frontpage summary
+			const cellText = [
+				`${costCenter.costCenter}`,
+				`${ccStartPage[costCenter.costCenter]}`,
+				`${totalVat}`,
+				`${totalNet}`,
+				`${totalNet + totalVat}`,
+				`${costCenterCurrency}`,
+			]
+			frontPage.moveDown(lineHeight)
+			cellText.forEach((text, index) => {
+				frontPage.drawText(text, {
+					x: xMargin + index * cellWidth,
+					size: fontSize,
+					font: font,
+				})
+			})
+		}
 		result = await pdfDoc.save()
 		return result
 	}

--- a/Receipt/index.ts
+++ b/Receipt/index.ts
@@ -82,7 +82,6 @@ export namespace Receipt {
 		pdfDoc.setCreationDate(new Date())
 		const width = PDFLib.PageSizes.A4[0]
 		let height = PDFLib.PageSizes.A4[1]
-
 		const fontSize = 12
 		const headerSize = Math.round(fontSize * 1.33)
 		const xMargin = 30
@@ -94,9 +93,7 @@ export namespace Receipt {
 		const headers = ["Page", "Vat", "Net", "Gross", "Currency"]
 		const receiptsPerIndexPage = (height - 2 * yMargin - fontSize / 2) / lineHeight
 		const ccStartPage: Record<string, number> = {}
-
 		const frontPage = pdfDoc.addPage([width, height])
-
 		const indexPages = Array.from({
 			length: Math.ceil(
 				receiptData.reduce((total, costCenter) => total + costCenter.receipts.length, 0) / receiptsPerIndexPage
@@ -108,7 +105,6 @@ export namespace Receipt {
 		for (const [i, indexPage] of indexPages.entries()) {
 			for (const CostCenter of indexPage) {
 				const page = pdfDoc.addPage([width, height])
-
 				page.drawText(`Summary for cost center: ${CostCenter.costCenter}`, { x: xMargin, y: height - yMargin })
 				ccStartPage[CostCenter.costCenter] = pdfDoc.getPageCount()
 				height -= 20
@@ -120,7 +116,6 @@ export namespace Receipt {
 					})
 				)
 				page.moveTo(xMargin, height - yMargin - fontSize / 2)
-
 				page.drawLine({
 					start: { x: xMargin, y: height - yMargin - lineThickness - lineMargin },
 					end: { x: width - xMargin, y: height - yMargin - lineThickness - lineMargin },
@@ -133,7 +128,6 @@ export namespace Receipt {
 						([n, v], { net: [net], vat: [vat] }) => [n + net, v + vat],
 						[0, 0]
 					)
-
 					const cellText = [
 						`${pdfDoc.getPageCount() + indexPages.length - i}`,
 						`${vat} `,
@@ -191,7 +185,6 @@ export namespace Receipt {
 					receipt.details.total.reduce(([v, n], { net: [net], vat: [vat] }) => [net + v, vat + n], [vat, net]),
 				[0, 0]
 			)
-
 			const cellText = [
 				`${costCenter.costCenter}`,
 				`${ccStartPage[costCenter.costCenter]}`,

--- a/Receipt/index.ts
+++ b/Receipt/index.ts
@@ -1,6 +1,7 @@
 import * as cryptly from "cryptly"
 import * as isoly from "isoly"
 import * as PDFLib from "pdf-lib"
+import { rotateAndSkewTextDegreesAndTranslate } from "pdf-lib"
 import { Delegation } from "../Delegation"
 import { Purchase } from "../Purchase"
 import { Transaction } from "../Transaction"
@@ -202,8 +203,8 @@ export namespace Receipt {
 				})
 			})
 		}
-		for (let i = 1; i <= pdfDoc.getPageCount(); i++) {
-			pdfDoc.getPage(i).drawText(`${i}/${pdfDoc.getPageCount()}`, { x: 20, y: 20, size: 12 })
+		for (let i = 0; i < pdfDoc.getPageCount(); i++) {
+			pdfDoc.getPage(i).drawText(`${i + 1}/${pdfDoc.getPageCount()}`, { x: 20, y: 20, size: 12 })
 		}
 		result = await pdfDoc.save()
 		return result

--- a/Receipt/index.ts
+++ b/Receipt/index.ts
@@ -1,7 +1,6 @@
 import * as cryptly from "cryptly"
 import * as isoly from "isoly"
 import * as PDFLib from "pdf-lib"
-import { rotateAndSkewTextDegreesAndTranslate } from "pdf-lib"
 import { Delegation } from "../Delegation"
 import { Purchase } from "../Purchase"
 import { Transaction } from "../Transaction"


### PR DESCRIPTION
Reworked receipts compiler to be able to take an array of cost centers and their receipts.

Test document can be viewed in `receiptsresult.pdf`

 
