### PR TITLE
relies on default blob instead of cloudly-form

### DIFF
--- a/Receipt/Creatable.spec.ts
+++ b/Receipt/Creatable.spec.ts
@@ -29,12 +29,12 @@ describe("Receipt.Creatable", () => {
 		expect(file.type).toEqual("")
 		expect(typeof file.lastModified).toEqual("number")
 	})
-	it("parse", () => {
+	it("parse", async () => {
 		let form: any = {
 			data: '{"total":[]}',
-			file: { data: new Uint8Array([97]) },
+			file: new Blob([new Uint8Array([97])]),
 		}
-		expect(model.Receipt.Creatable.parse(form)).toEqual({
+		expect(await model.Receipt.Creatable.parse(form)).toEqual({
 			total: [],
 			file: new Uint8Array([97]),
 		})
@@ -43,15 +43,15 @@ describe("Receipt.Creatable", () => {
 			vat: 1,
 			file: form.file,
 		}
-		expect(model.Receipt.Creatable.parse(form)).toEqual(undefined)
+		expect(await model.Receipt.Creatable.parse(form)).toEqual(undefined)
 		form = {
 			data: JSON.stringify(JSON.stringify([])),
 			file: form.file,
 		}
-		expect(model.Receipt.Creatable.parse(form)).toEqual(undefined)
-		expect(model.Receipt.Creatable.parse({ data: '{"total":[]}', file: form.file })).toEqual({
+		expect(await model.Receipt.Creatable.parse(form)).toEqual(undefined)
+		expect(await model.Receipt.Creatable.parse({ data: '{"total":[]}', file: form.file })).toEqual({
 			total: [],
-			file: form.file.data,
+			file: new Uint8Array([97]),
 		})
 	})
 	it("validate", () => {

--- a/Receipt/Creatable.ts
+++ b/Receipt/Creatable.ts
@@ -27,9 +27,7 @@ export namespace Creatable {
 		form.append("file", receipt.file instanceof Blob ? receipt.file : new Blob([receipt.file]))
 		return form
 	}
-	export async function parse(
-		form: { data: string; file: { data: Uint8Array } } | any
-	): Promise<Creatable | undefined> {
+	export async function parse(form: { data: string; file: Blob } | any): Promise<Creatable | undefined> {
 		let result: Creatable | undefined
 		if (typeof form != "object" || !form || typeof form.data != "string" || typeof form.file != "object" || !form.file)
 			result = undefined

--- a/Receipt/Creatable.ts
+++ b/Receipt/Creatable.ts
@@ -27,14 +27,19 @@ export namespace Creatable {
 		form.append("file", receipt.file instanceof Blob ? receipt.file : new Blob([receipt.file]))
 		return form
 	}
-	export function parse(form: { data: string; file: { data: Uint8Array } } | any): Creatable | undefined {
-		let r: Creatable | undefined
+	export async function parse(
+		form: { data: string; file: { data: Uint8Array } } | any
+	): Promise<Creatable | undefined> {
+		let result: Creatable | undefined
 		if (typeof form != "object" || !form || typeof form.data != "string" || typeof form.file != "object" || !form.file)
-			r = undefined
+			result = undefined
 		else {
 			const parsed = JSON.parse(form.data)
-			r = typeof parsed != "object" || !parsed ? undefined : Object.assign(parsed, { file: form.file.data })
+			result =
+				typeof parsed != "object" || !parsed || !(form.file instanceof Blob)
+					? undefined
+					: Object.assign(parsed, { file: new Uint8Array(await form.file.arrayBuffer()) })
 		}
-		return !is(r) ? undefined : r
+		return !is(result) ? undefined : result
 	}
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"lint": "eslint '**/*.{ts,tsx}'",
 		"fix": "eslint '**/*.{ts,tsx}' --fix",
 		"build": "tsc -p .",
-		"test": "jest --maxWorkers=2",
+		"test": "jest",
 		"test:watch": "watch jest",
 		"prepare": "npm run build",
 		"clean": "rimraf dist node_modules coverage"


### PR DESCRIPTION
* using native blobs instead of type return by cloudly-formdata
  * made parse function async as it is required for blob -> Uint8Array
  * removed data property as blob does not have that